### PR TITLE
chore: bump vib action, update recommended extensions

### DIFF
--- a/.github/workflows/image.yml
+++ b/.github/workflows/image.yml
@@ -17,7 +17,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4
  
-    - uses: vanilla-os/vib-gh-action@v0.6.2
+    - uses: vanilla-os/vib-gh-action@v0.7.0
       with:
         recipe: 'recipe.yml'
     

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,3 +1,3 @@
 {
-  "recommendations": ["Vue.volar", "Vue.vscode-typescript-vue-plugin"]
+  "recommendations": ["Vue.volar"]
 }


### PR DESCRIPTION
## Changes

- Bump Vib action version to `v0.7.0`.
- Update the `.vscode/extensions.json` file to remove the now deprecated `Vue.vscode-typescript-vue-plugin` plugin which is included in the official `Vue.volar` plugin directly.