### PR TITLE
fix(#156): remove useless icons on print

### DIFF
--- a/src/views/ArticleView.vue
+++ b/src/views/ArticleView.vue
@@ -83,18 +83,20 @@
       <div class="flex flex-row justify-center mt-2 align-middle">
         <p class="flex flex-row gap-2 justify-center items-center mt-4 text-gray-700 dark:text-gray-400">
           <b>Reading time:</b> {{ readingTime }}
-          <span class="print:hidden">&middot;</span>
-          <span
-            class="mdi material-symbols-outlined print:hidden select-none cursor-pointer"
+          <span class="inline-flex items-center justify-center gap-2 print:hidden">
+            <span>&middot;</span>
+            <span
+            class="mdi material-symbols-outlined select-none cursor-pointer"
             @click="printArticle"
             >print</span
-          >
-          <span class="print:hidden">&middot;</span>
-          <span
-            class="mdi material-symbols-outlined print:hidden select-none cursor-pointer"
-            @click="shareModalVisible = true"
-            >share</span
-          >
+            >
+            <span>&middot;</span>
+            <span
+              class="mdi material-symbols-outlined select-none cursor-pointer"
+              @click="shareModalVisible = true"
+              >share</span
+            >
+          </span>
         </p>
       </div>
     </div>


### PR DESCRIPTION
The icons are no longer present on print

![Screenshot 2025-02-27 at 16 57 08](https://github.com/user-attachments/assets/22b6a532-938f-41e5-815d-55b35d108784)

---

Closes #156 
